### PR TITLE
Add cohort report action

### DIFF
--- a/analysis/report.R
+++ b/analysis/report.R
@@ -62,9 +62,9 @@ summary(df_input_2$CVD_assess_latest_number)
 
 df_input_2$CVD_assess_cat <- ifelse(is.na(df_input_2$CVD_assess_latest_number), 0, 1)
 
-cvd.risk <- summary(as.factor(df_input_2$CVD_assess_cat))
+cvd_risk <- summary(as.factor(df_input_2$CVD_assess_cat))
 
-write.csv(cvd.risk, here("output", "report_cvd.risk.5years.csv"))
+write.csv(cvd_risk, here("output", "report_cvd_risk_5years.csv"))
 
 
 ## calculate % patients with CVD risk over 10 on statins (NA means not on statins)
@@ -75,9 +75,9 @@ summary(data_risk10$statins_prescribed)
 
 data_risk10$statin_cat <- ifelse(is.na(data_risk10$statins_prescribed), 0, 1)
 
-statin.risk10 <- summary(as.factor(data_risk10$statin_cat))
+statin_risk10 <- summary(as.factor(data_risk10$statin_cat))
 
-write.csv(statin.risk10, here("output", "report_statin.risk10.csv"))
+write.csv(statin_risk10, here("output", "report_statin_risk10.csv"))
 
 
 ## calculate % patients with CVD risk over 20 on statins (NA means not on statins)
@@ -88,9 +88,9 @@ summary(data_risk20$statins_prescribed)
 
 data_risk20$statin_cat <- ifelse(is.na(data_risk20$statins_prescribed), 0, 1)
 
-statin.risk20 <- summary(as.factor(data_risk20$statin_cat))
+statin_risk20 <- summary(as.factor(data_risk20$statin_cat))
 
-write.csv(statin.risk20, here("output", "report_statin.risk20.csv"))
+write.csv(statin_risk20, here("output", "report_statin_risk20.csv"))
 
 
 ## calculate % patients with pre-existing CVD on statins (NA means not on statins)
@@ -99,9 +99,9 @@ summary(df_cvd$statins_prescribed)
 
 df_cvd$statin_cat <- ifelse(is.na(df_cvd$statins_prescribed), 0, 1)
 
-statin.cvd <- summary(as.factor(df_cvd$statin_cat))
+statin_cvd <- summary(as.factor(df_cvd$statin_cat))
 
-write.csv(statin.cvd, here("output", "report_statin.cvd.csv"))
+write.csv(statin_cvd, here("output", "report_statin_cvd.csv"))
 
 
 ## calculate % patients with CKD on statins (NA means not on statins)
@@ -110,6 +110,6 @@ summary(df_ckd$statins_prescribed)
 
 df_ckd$statin_cat <- ifelse(is.na(df_ckd$statins_prescribed), 0, 1)
 
-statin.ckd <- summary(as.factor(df_ckd$statin_cat))
+statin_ckd <- summary(as.factor(df_ckd$statin_cat))
 
-write.csv(statin.ckd, here("output", "report_statin.ckd.csv"))
+write.csv(statin_ckd, here("output", "report_statin_ckd.csv"))

--- a/analysis/report.R
+++ b/analysis/report.R
@@ -1,9 +1,12 @@
 library('tidyverse')
+library(here)
 
+## Load data from cohort extractor
 df_input <- read_csv(
   here::here("output", "input.csv")
   )
 
+# Check format of data
 head(df_input)
 
 colnames(df_input)
@@ -12,23 +15,23 @@ nrow(df_input)
 
 
 
-## select patients with CVD 
+## select patients with CVD
 
-df_cvd <- df_input[df_input$CVD_code==1,]
+df_cvd <- df_input[df_input$CVD_code == 1, ]
 
 nrow(df_cvd)
 
 
-## select patients with CKD 
+## select patients with CKD
 
-df_ckd <- df_input[df_input$CKD_code==1,]
+df_ckd <- df_input[df_input$CKD_code == 1, ]
 
 nrow(df_ckd)
 
 
 ## exclude patients under 40 yo
 
-df_input <- df_input[df_input$age>=40,]
+df_input <- df_input[df_input$age >= 40, ]
 
 summary(df_input$age)
 
@@ -37,7 +40,7 @@ nrow(df_input)
 
 ## exclude patients with CVD, CKD or T1D
 
-df_input <- df_input[df_input$CVD_code==0 & df_input$CKD_code==0 & df_input$T1D_code==0,]
+df_input <- df_input[df_input$CVD_code == 0 & df_input$CKD_code == 0 & df_input$T1D_code == 0, ]
 
 nrow(df_input)
 
@@ -46,7 +49,7 @@ nrow(df_input)
 
 summary(df_input$CVD_assess_latest_date)
 
-df_input_2 <- df_input[df_input$CVD_assess_latest_date>="2017-01-01",]
+df_input_2 <- df_input[df_input$CVD_assess_latest_date >= "2017-01-01", ]
 
 summary(df_input_2$CVD_assess_latest_date)
 
@@ -61,12 +64,12 @@ df_input_2$CVD_assess_cat <- ifelse(is.na(df_input_2$CVD_assess_latest_number), 
 
 cvd.risk <- summary(as.factor(df_input_2$CVD_assess_cat))
 
-write.csv(cvd.risk, "cvd.risk.5years.csv")
+write.csv(cvd.risk, here("output", "cvd.risk.5years.csv"))
 
 
 ## calculate % patients with CVD risk over 10 on statins (NA means not on statins)
 
-data_risk10 <- df_input_2[df_input_2$CVD_assess_latest_number>=10,]
+data_risk10 <- df_input_2[df_input_2$CVD_assess_latest_number >= 10, ]
 
 summary(data_risk10$statins_prescribed)
 
@@ -74,12 +77,12 @@ data_risk10$statin_cat <- ifelse(is.na(data_risk10$statins_prescribed), 0, 1)
 
 statin.risk10 <- summary(as.factor(data_risk10$statin_cat))
 
-write.csv(statin.risk10, "statin.risk10.csv")
+write.csv(statin.risk10, here("output", "statin.risk10.csv"))
 
 
 ## calculate % patients with CVD risk over 20 on statins (NA means not on statins)
 
-data_risk20 <- df_input_2[df_input_2$CVD_assess_latest_number>=20,]
+data_risk20 <- df_input_2[df_input_2$CVD_assess_latest_number >= 20, ]
 
 summary(data_risk20$statins_prescribed)
 
@@ -87,7 +90,7 @@ data_risk20$statin_cat <- ifelse(is.na(data_risk20$statins_prescribed), 0, 1)
 
 statin.risk20 <- summary(as.factor(data_risk20$statin_cat))
 
-write.csv(statin.risk20, "statin.risk20.csv")
+write.csv(statin.risk20, here("output", "statin.risk20.csv"))
 
 
 ## calculate % patients with pre-existing CVD on statins (NA means not on statins)
@@ -98,7 +101,7 @@ df_cvd$statin_cat <- ifelse(is.na(df_cvd$statins_prescribed), 0, 1)
 
 statin.cvd <- summary(as.factor(df_cvd$statin_cat))
 
-write.csv(statin.cvd, "statin.cvd.csv")
+write.csv(statin.cvd, here("output", "statin.cvd.csv"))
 
 
 ## calculate % patients with CKD on statins (NA means not on statins)
@@ -109,5 +112,4 @@ df_ckd$statin_cat <- ifelse(is.na(df_ckd$statins_prescribed), 0, 1)
 
 statin.ckd <- summary(as.factor(df_ckd$statin_cat))
 
-write.csv(statin.ckd, "statin.ckd.csv")
-
+write.csv(statin.ckd, here("output", "statin.ckd.csv"))

--- a/analysis/report.R
+++ b/analysis/report.R
@@ -64,7 +64,7 @@ df_input_2$CVD_assess_cat <- ifelse(is.na(df_input_2$CVD_assess_latest_number), 
 
 cvd.risk <- summary(as.factor(df_input_2$CVD_assess_cat))
 
-write.csv(cvd.risk, here("output", "cvd.risk.5years.csv"))
+write.csv(cvd.risk, here("output", "report_cvd.risk.5years.csv"))
 
 
 ## calculate % patients with CVD risk over 10 on statins (NA means not on statins)
@@ -77,7 +77,7 @@ data_risk10$statin_cat <- ifelse(is.na(data_risk10$statins_prescribed), 0, 1)
 
 statin.risk10 <- summary(as.factor(data_risk10$statin_cat))
 
-write.csv(statin.risk10, here("output", "statin.risk10.csv"))
+write.csv(statin.risk10, here("output", "report_statin.risk10.csv"))
 
 
 ## calculate % patients with CVD risk over 20 on statins (NA means not on statins)
@@ -90,7 +90,7 @@ data_risk20$statin_cat <- ifelse(is.na(data_risk20$statins_prescribed), 0, 1)
 
 statin.risk20 <- summary(as.factor(data_risk20$statin_cat))
 
-write.csv(statin.risk20, here("output", "statin.risk20.csv"))
+write.csv(statin.risk20, here("output", "report_statin.risk20.csv"))
 
 
 ## calculate % patients with pre-existing CVD on statins (NA means not on statins)
@@ -101,7 +101,7 @@ df_cvd$statin_cat <- ifelse(is.na(df_cvd$statins_prescribed), 0, 1)
 
 statin.cvd <- summary(as.factor(df_cvd$statin_cat))
 
-write.csv(statin.cvd, here("output", "statin.cvd.csv"))
+write.csv(statin.cvd, here("output", "report_statin.cvd.csv"))
 
 
 ## calculate % patients with CKD on statins (NA means not on statins)
@@ -112,4 +112,4 @@ df_ckd$statin_cat <- ifelse(is.na(df_ckd$statins_prescribed), 0, 1)
 
 statin.ckd <- summary(as.factor(df_ckd$statin_cat))
 
-write.csv(statin.ckd, here("output", "statin.ckd.csv"))
+write.csv(statin.ckd, here("output", "report_statin.ckd.csv"))

--- a/project.yaml
+++ b/project.yaml
@@ -10,3 +10,11 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/input.csv
+
+  report_data:
+    run: r:latest analysis/report.R
+    needs:
+    - generate_study_population
+    outputs:
+      moderately_sensitive:
+        csv: output/report_*.csv

--- a/project.yaml
+++ b/project.yaml
@@ -18,3 +18,24 @@ actions:
     outputs:
       moderately_sensitive:
         csv: output/report_*.csv
+
+  generate_report:
+    run: cohort-report:v3.0.0 output/input.csv
+    needs: [generate_study_population]
+    config:
+      variable_types:
+          CVD_assess_latest_date: date
+          statins_prescribed: date
+          age: int
+          sex: categorical
+          CVD_assess_latest_number: float
+          CVD_assess_comparator: categorical
+          CKD_code: binary
+          CVD_code: binary
+          T1D_code: binary
+          T2D_code: binary
+          Overall_diab_code: binary
+      output_path: output/cohort_reports_outputs
+    outputs:
+      moderately_sensitive:
+        reports: output/cohort_reports_outputs/descriptives_input.html

--- a/project.yaml
+++ b/project.yaml
@@ -39,3 +39,4 @@ actions:
     outputs:
       moderately_sensitive:
         reports: output/cohort_reports_outputs/descriptives_input.html
+        reports_charts: output/cohort_reports_outputs/*.png


### PR DESCRIPTION
This pull request adds the reusable action https://github.com/opensafely-actions/cohort-report that gives a basic overview of the entire population, similar to the report.R script but without the subgroups. after running the following `opensafely run run_all -f` (or simply `opensafely run generate_report` if you only want to run this action)  in your terminal you should see the subfolder `cohort_reports_outputs` with an .html report